### PR TITLE
Windows: Build fastreplacestring with MingW toolchain on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 PREFIX=$(PWD)
 
+ifeq (, $(shell which x86_64-w64-mingw32-g++))
+GCC=g++
+else
+GCC=x86_64-w64-mingw32-g++
+endif
+
+
 build:
+	@echo Using compiler: $(GCC)
 	@mkdir -p $(PREFIX)/bin
-	@g++ -Ofast -o $(PREFIX)/bin/fastreplacestring ./fastreplacestring.cpp
+	@$(GCC) -Ofast -o $(PREFIX)/bin/fastreplacestring ./fastreplacestring.cpp
 
 test:
 	@node ./tests/test.js && node ./tests/xtest.js

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ PREFIX=$(PWD)
 ifeq (, $(shell which x86_64-w64-mingw32-g++))
 GCC=g++
 else
-GCC=x86_64-w64-mingw32-g++
+GCC=x86_64-w64-mingw32-c++
+GCC_EXTRA_ARGS=-static -static-libgcc -static-libstdc++
 endif
 
-
 build:
-	@echo Using compiler: $(GCC)
+	@echo Using compiler: $(GCC) with args: $(GCC_EXTRA_ARGS)
 	@mkdir -p $(PREFIX)/bin
-	@$(GCC) -Ofast -o $(PREFIX)/bin/fastreplacestring ./fastreplacestring.cpp
+	@$(GCC) $(GCC_EXTRA_ARGS) -o$(PREFIX)/bin/fastreplacestring.exe ./fastreplacestring.cpp
 
 test:
 	@node ./tests/test.js && node ./tests/xtest.js


### PR DESCRIPTION
__Issue:__ The existing compilation strategy doesn't work for Windows in the Cygwin shell. `g++` is not a cross-compiler for a native Windows executable, which is problematic.

__Fix:__ Use the `x86_64-w64-mingw32-g++ compiler` toolchain to build. In addition, we also need to pass in the `-static` argument so that several libraries, like the standard lib and other dependencies, are correct and not dependent on runtime environment.