### PR TITLE
Fix a couple issues with build in the context of esy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ PREFIX=$(PWD)
 ifeq (, $(shell which x86_64-w64-mingw32-g++))
 GCC=g++
 else
-GCC=x86_64-w64-mingw32-c++
+GCC=x86_64-w64-mingw32-g++
 GCC_EXTRA_ARGS=-static -static-libgcc -static-libstdc++
 endif
 
 build:
 	@echo Using compiler: $(GCC) with args: $(GCC_EXTRA_ARGS)
 	@mkdir -p $(PREFIX)/bin
-	@$(GCC) $(GCC_EXTRA_ARGS) -o$(PREFIX)/bin/fastreplacestring.exe ./fastreplacestring.cpp
+	@$(GCC) $(GCC_EXTRA_ARGS) -o$(PREFIX)/bin/fastreplacestring ./fastreplacestring.cpp
 
 test:
 	@node ./tests/test.js && node ./tests/xtest.js


### PR DESCRIPTION
When building the latest commit against https://github.com/esy/esy/pull/407, I saw a couple of issues:
- We were using `x86_64-w64-mingw32-c++` instead of `x86_64-w64-mingw32-g++`. I believe the output is the same, but we should use `g++` for consistency.
- An `.exe` extension was added unnecessarily, which broke the OSX / Linux builds